### PR TITLE
refactor: 라우트 마운트를 /api/<도메인> 네임스페이스로 통일

### DIFF
--- a/server.js
+++ b/server.js
@@ -62,9 +62,9 @@ app.use("/api", imageRoutes);
 app.use("/api/sale-posts", salePostRoutes);
 app.use("/api/blog-posts", blogPostRoutes);
 app.use("/api/messages", messageRoutes);
-app.use("/", myPageRoute);
-app.use("/", authRoutes);
-app.use("/", campsiteRoutes);
+app.use("/api/my-page", myPageRoute);
+app.use("/api/auth", authRoutes);
+app.use("/api/campsites", campsiteRoutes);
 app.use("/api/checkout", checkoutRoutes);
 
 db.connectDB();


### PR DESCRIPTION
server.js의 myPageRoute, authRoutes, campsiteRoutes 마운트 경로를 /api/my-page, /api/auth, /api/campsites로 변경